### PR TITLE
feat(WEB-392): add integrationVersion sync workflow

### DIFF
--- a/.github/workflows/sync-integration-version.yml
+++ b/.github/workflows/sync-integration-version.yml
@@ -1,0 +1,120 @@
+name: Sync Integration Version
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  sync-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout moengage-gtm-actions
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Extract version from metadata.yaml
+        run: |
+          NOTES=$(grep 'changeNotes:' metadata.yaml | tail -1 | sed -E "s/^[[:space:]]*changeNotes:[[:space:]]*//")
+          VERSION=$(echo "$NOTES" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract a semver version from the latest metadata.yaml changeNotes: $NOTES"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Update Moengage.setIntegrationVersion in template.tpl
+        run: |
+          if grep -qE "callInWindow\('Moengage\.setIntegrationVersion', [^)]+\);" template.tpl; then
+            sed -i -E "s/callInWindow\('Moengage\.setIntegrationVersion', [^)]+\);/callInWindow('Moengage.setIntegrationVersion', '${VERSION}');/" template.tpl
+          else
+            sed -i -E "s/^([[:space:]]*)data\.gtmOnSuccess\(\);/\1callInWindow('Moengage.setIntegrationVersion', '${VERSION}');\n\1data.gtmOnSuccess();/" template.tpl
+          fi
+          grep -qF "callInWindow('Moengage.setIntegrationVersion', '${VERSION}');" template.tpl || {
+            echo "::error::Failed to set Moengage.setIntegrationVersion to ${VERSION}"
+            exit 1
+          }
+
+      - name: Validate sandboxed JS still parses
+        run: |
+          sed -n '/^___SANDBOXED_JS_FOR_WEB_TEMPLATE___/,/^___WEB_PERMISSIONS___/p' template.tpl | sed '1d;$d' > /tmp/sandboxed.js
+          node --check /tmp/sandboxed.js
+
+      - name: Commit and push (own repo)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- template.tpl; then
+            echo "template.tpl already up to date, skipping commit"
+          else
+            git add template.tpl
+            git commit -m "chore: sync integrationVersion to ${VERSION}"
+            git push origin master
+          fi
+
+      - name: Checkout moengage-gtm-initialization
+        uses: actions/checkout@v4
+        with:
+          repository: moengage/moengage-gtm-initialization
+          ref: master
+          token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
+          path: gtm-init
+
+      - name: Update integrationVersion in moengage-gtm-initialization
+        working-directory: gtm-init
+        run: |
+          if grep -qE "data\.integrationVersion = [^;]+;" template.tpl; then
+            sed -i -E "s/data\.integrationVersion = [^;]+;/data.integrationVersion = '${VERSION}';/" template.tpl
+          else
+            sed -i -E "s/^([[:space:]]*)data\.integrationType = 'GTM';/\1data.integrationType = 'GTM';\n\1data.integrationVersion = '${VERSION}';/" template.tpl
+          fi
+          grep -qF "data.integrationVersion = '${VERSION}';" template.tpl || {
+            echo "::error::Failed to set data.integrationVersion to ${VERSION} in moengage-gtm-initialization/template.tpl"
+            exit 1
+          }
+
+      - name: Validate sandboxed JS still parses
+        working-directory: gtm-init
+        run: |
+          sed -n '/^___SANDBOXED_JS_FOR_WEB_TEMPLATE___/,/^___WEB_PERMISSIONS___/p' template.tpl | sed '1d;$d' > /tmp/sandboxed-init.js
+          node --check /tmp/sandboxed-init.js
+
+      - name: Commit template.tpl in moengage-gtm-initialization
+        id: commit_template
+        working-directory: gtm-init
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- template.tpl; then
+            echo "template.tpl already up to date in moengage-gtm-initialization, skipping"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git add template.tpl
+            git commit -m "chore: sync integrationVersion to ${VERSION}"
+            git push origin master
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Append metadata.yaml entry in moengage-gtm-initialization
+        if: steps.commit_template.outputs.changed == 'true'
+        working-directory: gtm-init
+        run: |
+          SHA="${{ steps.commit_template.outputs.sha }}"
+          {
+            echo "  - sha: ${SHA}"
+            echo "    changeNotes: ${VERSION} Bumped version because of the release in moengage-gtm-actions"
+          } >> metadata.yaml
+          git add metadata.yaml
+          git commit -m "chore: record integrationVersion ${VERSION} sync from moengage-gtm-actions"
+          git push origin master


### PR DESCRIPTION
Mirrors the workflow in moengage-gtm-initialization: on merge to master, derive the version from this repo's own metadata.yaml changeNotes, stamp it into template.tpl's Moengage.setIntegrationVersion call, and push the same update directly into moengage-gtm-initialization's master.